### PR TITLE
Increase buffer size by 100000 for blockchain import and export

### DIFF
--- a/src/blockchain_utilities/blockchain_utilities.h
+++ b/src/blockchain_utilities/blockchain_utilities.h
@@ -33,8 +33,10 @@
 
 // bounds checking is done before writing to buffer, but buffer size
 // should be a sensible maximum
-#define BUFFER_SIZE 1000000
-#define CHUNK_SIZE_WARNING_THRESHOLD 500000
+// Push the buffer up by 100000. Since V5 we can't import and exported chain
+#define BUFFER_SIZE 1100000
+// Raised the threshold by the same value added to buffer
+#define CHUNK_SIZE_WARNING_THRESHOLD 600000
 #define NUM_BLOCKS_PER_CHUNK 1
 #define BLOCKCHAIN_RAW "blockchain.raw"
 


### PR DESCRIPTION
This fixes the currently broken stellite-blockchain-import utility.
When you export the current chain, you'll see the following warnings:

```
2019-02-22 13:44:28.634        7fe755b76740    INFO     bcutil    src/blockchain_utilities/bootstrap_file.cpp:319    Number of blocks exported: 513501
2019-02-22 13:44:28.636        7fe755b76740    INFO     bcutil    src/blockchain_utilities/bootstrap_file.cpp:321    Largest chunk: 1034953 bytes
2019-02-22 13:44:28.641        7fe755b76740    WARN     bcutil    src/blockchain_utilities/blockchain_export.cpp:195    Blockchain raw data exported OK
```

__Largest chunk: 1034953 bytes__ is the issue here. Even though the buffer is set to 1000000, the exported doesn't honor it causing the import to fail with the error `Exception at [Import error], what=Aborting: chunk size exceeds buffer size`.

This PR raises the buffer size to 1100000 bytes (100000 bytes increase), which resolves the issue.

A reference from Monero [is in this issue](https://github.com/monero-project/monero/issues/2031) but that wasn't really solved. I can confirm the chain isn't corrupted as mentioned here as I did an export and import on the same server using a cleanly synced chain and import verification enabled.